### PR TITLE
Fix mustermann version to 0.4.0 because 1.0.0 requires Ruby version >…

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,4 +9,4 @@ gem 'json'
 gem 'nokogiri'
 gem 'data_mapper', '1.2.0'
 gem 'dm-sqlite-adapter', '1.2.0'
-
+gem 'mustermann', '0.4.0'


### PR DESCRIPTION
Gemfile modification
Fix mustermann version to 0.4.0 because 1.0.0 requires Ruby version >= 2.2.0
