### PR TITLE
Patching Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,5 +7,4 @@ RUN git clone --depth=1 https://github.com/BuffaloWill/oxml_xxe.git /oxml_xxe &&
     bundle install
 WORKDIR /oxml_xxe
 EXPOSE 4567
-ENTRYPOINT ["ruby", "server.rb"]
-CMD ["-o", "0.0.0.0"]
+ENTRYPOINT ["ruby", "server.rb", "-o", "0.0.0.0"]


### PR DESCRIPTION
Depending on the HV, Docker version and underlying OS something prevents the args specified in CMD to be applied.

Hitting this on MacOS Catalina

This is a simple fix and in most cases this image will just be running with the defaults